### PR TITLE
Impersonate

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -82,12 +82,31 @@ var _switchUser = function (userToken) {
   _this.tenantId = jwtDecode(userToken.authToken).app_metadata.tenantId;
 }
 
+var _impersonate = function (customerId, impersonationToken) {
+  // TODO: replace url with solinkcloud URL once deployed
+  var url = 'https://test-callhome.solinkcloud.com/api/auth/impersonate';
+  return fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${impersonationToken}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      tenantId: customerId
+    })
+  }).then(res => {
+    return res.json();
+  });
+}
+
 module.exports = function(connection) {
   return {
     login: _login.bind(connection),
     setPassword: _setPassword.bind(connection),
     forgotPassword: _forgotPassword.bind(connection),
     refresh: _refresh.bind(connection),
-    switchUser: _switchUser.bind(connection)
+    switchUser: _switchUser.bind(connection),
+    impersonate: _impersonate.bind(connection)
   }
 }

--- a/src/auth.js
+++ b/src/auth.js
@@ -83,8 +83,7 @@ var _switchUser = function (userToken) {
 }
 
 var _impersonate = function (customerId, impersonationToken) {
-  // TODO: replace url with solinkcloud URL once deployed
-  var url = 'https://test-callhome.solinkcloud.com/api/auth/impersonate';
+  var url = URL.resolve(authUrl(this.host), 'impersonate');
   return fetch(url, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
Added an `impersonate` API endpoint to solink.js.  This is used for handling customer impersonation from solink/cloud/reseller users.

Currently being used by my `impersonate` branch on the Video Discovery web project