### PR TITLE
Replace the ES6 arrow function within auth.js

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -94,7 +94,7 @@ var _impersonate = function (customerId, impersonationToken) {
     body: JSON.stringify({
       tenantId: customerId
     })
-  }).then(res => {
+  }).then(function(res) {
     return res.json();
   });
 }


### PR DESCRIPTION
This is to keep ES6 out of the library